### PR TITLE
feat: Add git tag to ldflags for version tracking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Extract git tag
+        shell: bash
+        run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
+        id: extract_tag
       - name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -36,7 +40,7 @@ jobs:
           go install github.com/wailsapp/wails/v2/cmd/wails@v2.4.0
       - name: Build Wails app
         run: |
-          wails build -platform ${{ matrix.target }}
+          wails build -platform ${{ matrix.target }} -ldflags "-X main.version=${{ steps.extract_tag.outputs.tag }}"
       - name: Import macOS Certificates
         if: startsWith(matrix.os, 'macos')
         uses: apple-actions/import-codesign-certs@v2
@@ -52,10 +56,6 @@ jobs:
         with:
           name: relingo-desktop-${{ matrix.build_target }}
           path: build/bin/*
-      - name: Extract git tag
-        shell: bash
-        run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
-        id: extract_tag
       - name: Packaging assets
         shell: bash
         if: startsWith(github.ref, 'refs/tags/')

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ var assets embed.FS
 //go:embed build/appicon.png
 var icon []byte
 
+var version string
+
 func main() {
 	// Create an instance of the app structure
 	app := NewApp()
@@ -27,7 +29,7 @@ func main() {
 		Mac: &mac.Options{
 			About: &mac.AboutInfo{
 				Title:   "Relingo Desktop",
-				Message: "© 2022 Bonaysoft",
+				Message: "\nVersion. " + version + "\n\nCopyright © 2022-2023 Bonaysoft.",
 				Icon:    icon,
 			},
 		},


### PR DESCRIPTION
- Extract git tag in GitHub Actions workflow
- Pass git tag to wails build command with ldflags
- Add version variable to main.go for easier version tracking
